### PR TITLE
members: fix typos in pedram's details

### DIFF
--- a/_pages/members.md
+++ b/_pages/members.md
@@ -125,7 +125,7 @@ nav_order: 2
 </tr>
 <tr>
 <td style="width: 30%;">{% include figure.html path="assets/img/paa.jpg" title="example image" width="200" height="200" class="img-fluid rounded z-depth-1" %}</td>
-<td style="width: 70%;"><strong>Pedram Ashofteh Ardakani</strong><br />Master&nbsp;in Atomic and Molecular Physics (2018&nbsp;to&nbsp;2020)<br />Research Topic: Design study of a laser spectrometer using multipass cells<br />Email:&nbsp;<a href="mailto:pedramardakani@pm.me"><span style="font-weight: 400;">pedramardakani@pm.me</span></a><br />Now @ Software Developer at the GNU Project (Boston, Massachusetts, United States - Remote) and the Iranian National Observatory (Tehran, Iran - Remote)&nbsp;LSRL</td>
+<td style="width: 70%;"><strong>Pedram Ashofteh Ardakani</strong><br />Master&nbsp;in Atomic and Molecular Physics (2016&nbsp;to&nbsp;2019)<br />Research Topic: Design study of a laser spectrometer using multipass cells<br />Email:&nbsp;<a href="mailto:pedramardakani@pm.me"><span style="font-weight: 400;">pedramardakani@pm.me</span></a><br />Now @ Software Developer at the GNU Project (Boston, Massachusetts, United States - Remote) and the Iranian National Observatory (Tehran, Iran - Remote)</td>
 </tr>
 <tr>
 <td style="width: 30%;">{% include figure.html path="assets/img/LSRL.jpg" title="example image" width="200" height="200" class="img-fluid rounded z-depth-1" %}</td>


### PR DESCRIPTION
Now, the exact admission and graduation years are stated. Also, the  extra "LSRL" at the end of the "Now @" record is removed.